### PR TITLE
feat: Create autoload for `consult-company`.

### DIFF
--- a/consult-company.el
+++ b/consult-company.el
@@ -85,6 +85,7 @@
               (add-text-properties 0 1 (list 'consult--type (cadr narrow)) cand-str))
            collect (cons cand-str cand)))
 
+;;;###autoload
 (defun consult-company ()
   "Interactively complete company candidates."
   (interactive)


### PR DESCRIPTION
Hi! This is a very simple change but powerful. I figure a lot of people would like to lazy load this package after calling it's keybinding, but surprisingly this package doesn't define an autoload function to do it, forcing the user to create his own. 


I think `consult-company` is a reasonably entry symbol to load this package so it should be added by default.
