### PR TITLE
[WIP] Preview completion documentation and locations

### DIFF
--- a/consult-company.el
+++ b/consult-company.el
@@ -157,7 +157,8 @@ quitting."
             (funcall preview-action location)))
         ;; Restore the original window configuration.
         (when (and split-window (eq action 'return))
-          (set-window-configuration window-configuration))))))
+          (ignore-errors
+            (set-window-configuration window-configuration)))))))
 
 (defun consult-company--candidate-location (orig-buffer cand)
   "Map a `company' CAND to its location.

--- a/consult-company.el
+++ b/consult-company.el
@@ -143,7 +143,9 @@ quitting."
         ;; Create a split if previews should be in a split.
         (when (and location
                    window-configuration
-                   (not split-window))
+                   (or
+                    (not split-window)
+                    (not (window-valid-p split-window))))
           (setq split-window
                 (display-buffer
                  (if (markerp location)
@@ -158,7 +160,8 @@ quitting."
         ;; Restore the original window configuration.
         (when (and split-window (eq action 'return))
           (ignore-errors
-            (set-window-configuration window-configuration)))))))
+            (set-window-configuration window-configuration))
+          (setq split-window nil))))))
 
 (defun consult-company--candidate-location (orig-buffer cand)
   "Map a `company' CAND to its location.

--- a/consult-company.el
+++ b/consult-company.el
@@ -162,7 +162,8 @@ quitting."
 (defun consult-company--candidate-location (orig-buffer cand)
   "Map a `company' CAND to its location.
 ORIG-BUFFER should be the buffer CAND was generated in."
-  (when-let ((location
+  (when-let ((cand cand)
+             (location
               (with-current-buffer orig-buffer
                 (company-call-backend 'location cand))))
     (let ((marker (make-marker)))
@@ -186,7 +187,8 @@ generated."
 (defun consult-company--candidate-doc-buffer (orig-buffer cand)
   "Map a `company' CAND to a documentation buffer and marker.
 ORIG-BUFFER should be the buffer CAND was generated in."
-  (when-let ((doc-buffer
+  (when-let ((cand cand)
+             (doc-buffer
               (with-current-buffer orig-buffer
                 (company-call-backend 'doc-buffer cand))))
     (get-buffer


### PR DESCRIPTION
Lets you see the help buffers for completion candidates. Supports variants for both `company-show-location` and `company-show-doc-buffer`. There's also a separate customization variable to show the previews in a temporary popup window (defaults to true) to avoid overloading the same window where you're completing the candidate.

WARN: The location preview isn't maintained by us. It's on a backend by backend basis which means the backend could open a bunch of files as we filter the completion and then clean it up. Not a big fan of this :/. That's why the default is to show the doc-buffer instead of the completion. I'll have to look into a nicer way to support the other approach down the line.

NOTE: This PR is just to make the intention clear. I intend to keep it open for a while and experiment with the new feature before merging.